### PR TITLE
Update version golang to matrix (1.19, 1.20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,20 @@ name: GitHub Actions CI
 
 on:
   push:
-    branches: [main, og/ci]
+    branches: [main]
   pull_request: {}
 
 jobs:
   ci:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.19', '1.20' ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: ${{ matrix.go }}
       - run: make tools
       - run: make depscheck
       - run: make lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,27 +17,29 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.19', '1.20' ]
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Unshallow
+        
+      - name: Unshallow
         run: git fetch --prune --unshallow
-      -
-        name: Set up Go
+
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
-      -
-        name: Import GPG key
+          go-version: ${{ matrix.go }}
+
+      - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5.2.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
-      -
-        name: Run GoReleaser
+
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-thebastion
 
-go 1.20
+go 1.19
 
 require github.com/hashicorp/terraform-plugin-framework v1.2.0
 


### PR DESCRIPTION
## Description

Put in ci a matrix of go version with 1.19 and 1.20. 
Version 1.19 was used mainly during testing and development of provider.
